### PR TITLE
Add tags, update gitignore to include jetbrains .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 vendor/
+
+.idea/

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -17,20 +17,39 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-func NewSentryRoundTripper(originalRoundTripper http.RoundTripper, tracePropagationTargets []string) http.RoundTripper {
+type SentryRoundTripTracerOption func(*SentryRoundTripper)
+
+func WithTags(tags map[string]string) SentryRoundTripTracerOption {
+	return func(t *SentryRoundTripper) {
+		for k, v := range tags {
+			t.tags[k] = v
+		}
+	}
+}
+
+func NewSentryRoundTripper(originalRoundTripper http.RoundTripper, tracePropagationTargets []string, opts ...SentryRoundTripTracerOption) http.RoundTripper {
 	if originalRoundTripper == nil {
 		originalRoundTripper = http.DefaultTransport
 	}
 
-	return &SentryRoundTripper{
+	t := &SentryRoundTripper{
 		originalRoundTripper:    originalRoundTripper,
 		tracePropagationTargets: tracePropagationTargets,
+		tags:                    make(map[string]string),
 	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t
 }
 
 type SentryRoundTripper struct {
 	originalRoundTripper    http.RoundTripper
 	tracePropagationTargets []string
+
+	tags map[string]string
 }
 
 func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
@@ -51,6 +70,11 @@ func (s *SentryRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 	cleanRequestURL := request.URL.Path
 
 	span := sentry.StartSpan(ctx, "http.client", sentry.WithTransactionName(fmt.Sprintf("%s %s", request.Method, cleanRequestURL)))
+
+	for k, v := range s.tags {
+		span.SetTag(k, v)
+	}
+
 	defer span.Finish()
 
 	span.SetData("http.query", request.URL.Query().Encode())

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -27,6 +27,12 @@ func WithTags(tags map[string]string) SentryRoundTripTracerOption {
 	}
 }
 
+func WithTag(key, value string) SentryRoundTripTracerOption {
+	return func(t *SentryRoundTripper) {
+		t.tags[key] = value
+	}
+}
+
 func NewSentryRoundTripper(originalRoundTripper http.RoundTripper, tracePropagationTargets []string, opts ...SentryRoundTripTracerOption) http.RoundTripper {
 	if originalRoundTripper == nil {
 		originalRoundTripper = http.DefaultTransport

--- a/pgxtracer/pgxtracer.go
+++ b/pgxtracer/pgxtracer.go
@@ -40,6 +40,12 @@ func WithTags(tags map[string]string) SentryPgxTracerOption {
 	}
 }
 
+func WithTag(key, value string) SentryPgxTracerOption {
+	return func(t *Tracer) {
+		t.tags[key] = value
+	}
+}
+
 func NewSentryPgxTracer(opts ...SentryPgxTracerOption) pgx.QueryTracer {
 	t := &Tracer{
 		tags: make(map[string]string),

--- a/pgxtracer/pgxtracer.go
+++ b/pgxtracer/pgxtracer.go
@@ -30,11 +30,31 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func NewSentryPgxTracer() pgx.QueryTracer {
-	return &Tracer{}
+type SentryPgxTracerOption func(*Tracer)
+
+func WithTags(tags map[string]string) SentryPgxTracerOption {
+	return func(t *Tracer) {
+		for k, v := range tags {
+			t.tags[k] = v
+		}
+	}
 }
 
-type Tracer struct{}
+func NewSentryPgxTracer(opts ...SentryPgxTracerOption) pgx.QueryTracer {
+	t := &Tracer{
+		tags: make(map[string]string),
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t
+}
+
+type Tracer struct {
+	tags map[string]string
+}
 
 func (t Tracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
 	span := sentry.StartSpan(ctx, "db.sql.query", sentry.WithTransactionName(data.SQL), sentry.WithDescription(data.SQL))
@@ -50,6 +70,10 @@ func (t Tracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, data pgx.Trac
 	span := sentry.SpanFromContext(ctx)
 	if span == nil {
 		return
+	}
+
+	for k, v := range t.tags {
+		span.SetTag(k, v)
 	}
 
 	if data.CommandTag.Insert() {

--- a/redistracer/redistracer.go
+++ b/redistracer/redistracer.go
@@ -25,6 +25,12 @@ func WithTags(tags map[string]string) SentryRedisTracerOption {
 	}
 }
 
+func WithTag(key, value string) SentryRedisTracerOption {
+	return func(t *SentryRedisTracer) {
+		t.tags[key] = value
+	}
+}
+
 func NewSentryRedisTracer(opts ...SentryRedisTracerOption) redis.Hook {
 	t := &SentryRedisTracer{}
 


### PR DESCRIPTION
Stumbled across this repository while looking for documentation on the Sentry tags/data/operation/name needed to get Database transactions to show correctly. It's a nice and straightforward repository, but it would be nice to be able to add tags to the tracers. As an example, I have a pgxpool for write & read, would be nice to be able to tag those appropriately.